### PR TITLE
更新北理主页链接

### DIFF
--- a/univ/1011.js
+++ b/univ/1011.js
@@ -3,7 +3,7 @@ var univ_list = {
     id: "1011",
     link: [ {
         name: "北理主页",
-        url: "https://www.bit.edu.cn/"
+        url: "http://www.bit.edu.cn/"
     }, {
         name: "教务处",
         url: "http://jwc.bit.edu.cn/"


### PR DESCRIPTION
事实证明 我校官网并没有 `https` 加持 🤦‍♂️ 